### PR TITLE
Center Strategic Alliance section heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,8 +193,8 @@
   <section id="alliance" class="py-14">
     <div class="container px-4">
       <div class="card p-8 rounded-xl">
-        <div class="max-w-5xl">
-          <h2 class="text-3xl font-bold tracking-tight">Strategic Alliance</h2>
+        <div class="max-w-5xl mx-auto">
+          <h2 class="text-3xl font-bold tracking-tight text-center">Strategic Alliance</h2>
 
           <div class="mt-6 space-y-6 text-[18px] leading-8">
             <p>Consulting For Capital is a partnership built on a belief in the power of cross-border, sector-focused teams, entrepreneurial spirit and investment in top-tier talent to produce outstanding results for our clients and employees.</p>


### PR DESCRIPTION
## Summary
- Center the Strategic Alliance section by adding `mx-auto` to its container and `text-center` to the heading.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9e3d11b4832cbe8e02bb5f5cda53